### PR TITLE
fix: clientid 로컬스토리지 저장 및 이메일체크 api 수정

### DIFF
--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -27,9 +27,16 @@ export default function Login() {
 
   const router = useRouter();
 
-  let clientId = "";
+  const [clientId, setClientId] = useState("");
   useEffect(() => {
-    clientId = uuidv4();
+    const id = localStorage.getItem("clientId");
+    if (id) {
+      setClientId(id);
+    } else {
+      const id = uuidv4();
+      localStorage.setItem("clientId", uuidv4());
+      setClientId(id);
+    }
   }, []);
 
   // 탭 전환

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -153,11 +153,15 @@ export const authApi = {
   /** 인증 번호 확인 */
   checkCertification: async (email: string, certification: string) => {
     try {
-      const res = await axios.post(`${API_URL}/check-certification`, {
-        email,
-        certification
-      })
-      return res.data
+      const res = await fetch(`${API_URL}/check-certification`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, certification }),
+      });
+      const res_json = await res.json()
+      return res_json;
     } catch (error) {
       console.error("인증 번호 확인 API 호출 중 에러: ", error);
     }


### PR DESCRIPTION
## 변경 사항 요약

- clientId를 로컬 스토리지에 저장
- 이메일체크 요청을 axios로 보내면 400번대는 throw 해버려서 응답값을 사용할 수 없어서 fetch 로 변경

## 관련 이슈

- Closes #41 

## 변경 상세 내용

- src/components/login/Login.tsx
  localStorage 사용해서 clientId 저장
- src/services/api.ts
  checkCertification 함수 axios -> fetch
  변경사유: 400번대로 오는 응답은 axios에서 error 로 throw 해버려서 응답값을 사용할 수 없어서

## 테스트 방법

- 변경 사항을 검증하기 위한 테스트 방법과 환경을 설명합니다.
- 수동 테스트 시나리오나 자동화 테스트 결과를 함께 기입할 수 있습니다.

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 모든 테스트 통과
- [ ] 문서 및 주석 업데이트 완료 (해당 시)

## 기타 참고 사항

- 추가로 참고할 자료나 설명이 필요한 경우 기입합니다.
