### PR TITLE
fix: 축제 이미지 이동 버그

### DIFF
--- a/src/app/festival/_components/ImageSwiper.tsx
+++ b/src/app/festival/_components/ImageSwiper.tsx
@@ -15,7 +15,7 @@ export default function ImageSwiper({ images }: Props) {
   return (
     <Swiper
       slidesPerView={1}
-      loop={true}
+      // loop={true} // navigation 한번만 눌러지는 버그로 임시로 비활성화
       pagination={{ clickable: true }}
       navigation={true}
       modules={[Pagination, Navigation]}


### PR DESCRIPTION
## 변경 사항 요약

- 축제 상세 페이지에서 이미지 다음 이전 버튼 한번만 눌리고, pagination 버튼 바로 다음 버튼 안눌리는 버그 무한슬라이드를 제거하여 임시 해결

## 관련 이슈

- Closes #45 

## 변경 상세 내용

- src/app/festival/_components/ImageSwiper.tsx
- loop={true} 를 비활성화 시켜 임시 해결
- 아이러니한 점은 merge 전엔 loop={true} 도 잘 작동했고, merge 내용을 살펴봐도 딱히 영향을 줄만한 것들을 찾을 수 없었다.

## 테스트 방법

- 변경 사항을 검증하기 위한 테스트 방법과 환경을 설명합니다.
- 수동 테스트 시나리오나 자동화 테스트 결과를 함께 기입할 수 있습니다.

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 모든 테스트 통과
- [ ] 문서 및 주석 업데이트 완료 (해당 시)

## 기타 참고 사항

- 추가로 참고할 자료나 설명이 필요한 경우 기입합니다.
