### PR TITLE
feat: 주간 여행지 탭 구성

### DIFF
--- a/src/app/week/_components/Course.tsx
+++ b/src/app/week/_components/Course.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { AreaBasedList } from "@/types/tourInfo";
+
+interface Props {
+  area: string;
+  areaBasedList: AreaBasedList[];
+}
+
+export default function Course({ area, areaBasedList }: Props) {
+  return (
+    <section className="mx-auto px-4 py-12 max-w-7xl">
+      <h2 className="text-3xl font-bold mb-10 text-center">{area} 추천 코스</h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {areaBasedList.map((area, index) => (
+          <div
+            key={index}
+            className="rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition duration-300 bg-white"
+          >
+            <div className="h-48 md:h-56 w-full bg-gray-200">
+              {area.firstimage ? (
+                <img src={area.firstimage} alt={area.imgname} className="w-full h-full object-cover" />
+              ) : (
+                <div className="flex items-center justify-center w-full h-full bg-gray-100 text-gray-500">
+                  이미지 없음
+                </div>
+              )}
+            </div>
+            <div className="p-6">
+              <h3 className="text-xl font-semibold mb-2">{area.title}</h3>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/week/_components/Event.tsx
+++ b/src/app/week/_components/Event.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { AreaBasedList } from "@/types/tourInfo";
+import { FaCalendarAlt, FaMapMarkerAlt } from "react-icons/fa";
+import getDetailIntro from "@/app/festival/_services/getDetailIntro";
+import { formatDateDot } from "@/utils/dateUtils";
+
+interface Props {
+  area: string;
+  areaBasedList: AreaBasedList[];
+}
+
+interface FestivalDetail {
+  eventstartdate?: string;
+  eventenddate?: string;
+  eventplace?: string;
+}
+
+export default function Event({ area, areaBasedList }: Props) {
+  const [details, setDetails] = useState<Record<string, FestivalDetail>>({});
+
+  useEffect(() => {
+    const fetchDetails = async () => {
+      try {
+        const promises = areaBasedList.map((festival) => getDetailIntro(festival.contentid));
+        const results = await Promise.all(promises);
+
+        const detailMap: Record<string, FestivalDetail> = {};
+        results.forEach((res) => {
+          const item = res.response.body.items.item[0];
+          if (item) {
+            detailMap[item.contentid] = {
+              eventstartdate: item.eventstartdate,
+              eventenddate: item.eventenddate,
+              eventplace: item.eventplace,
+            };
+          }
+        });
+
+        setDetails(detailMap);
+      } catch (error) {
+        console.error("축제 상세 정보를 가져오는 데 실패했습니다", error);
+      }
+    };
+
+    if (areaBasedList.length > 0) {
+      fetchDetails();
+    }
+  }, [areaBasedList]);
+
+  return (
+    <section className="mx-auto px-4 py-16 max-w-6xl">
+      <h2 className="text-3xl font-bold mb-12 text-center">{area}에서 열리는 이벤트</h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {areaBasedList.map((event, index) => {
+          const detail = details[event.contentid];
+          return (
+            <Link
+              key={index}
+              href={`/festival/detail/${event.contentid}`}
+              className="relative rounded-2xl overflow-hidden shadow-lg bg-white transition-all duration-500 hover:-translate-y-2 hover:shadow-2xl group block"
+            >
+              {/* 이미지 */}
+              <div className="h-56 overflow-hidden">
+                {event.firstimage ? (
+                  <img
+                    src={event.firstimage}
+                    alt={event.title}
+                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+                  />
+                ) : (
+                  <div className="flex items-center justify-center w-full h-full bg-gray-100 text-gray-500">
+                    이미지 없음
+                  </div>
+                )}
+              </div>
+
+              {/* 내용 */}
+              <div className="p-6">
+                <h3 className="text-xl font-semibold mb-2">{event.title}</h3>
+
+                {/* 날짜 */}
+                {detail?.eventstartdate && (
+                  <div className="flex items-center text-gray-500 text-sm mb-2">
+                    <FaCalendarAlt className="mr-2 text-pink-500" />
+                    {formatDateDot(detail.eventstartdate)} ~ {formatDateDot(detail.eventenddate)}
+                  </div>
+                )}
+
+                {/* 장소 */}
+                {detail?.eventplace && (
+                  <div className="flex items-center text-gray-500 text-sm mb-2">
+                    <FaMapMarkerAlt className="mr-2 text-blue-500" />
+                    {detail.eventplace}
+                  </div>
+                )}
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/week/_components/GoodPirce.tsx
+++ b/src/app/week/_components/GoodPirce.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { AreaBasedList } from "@/types/tourInfo";
+import { FaStore, FaMapMarkerAlt } from "react-icons/fa";
+
+interface Props {
+  area: string;
+  areaBasedList: AreaBasedList[];
+}
+
+export default function GoodPrice({ area, areaBasedList }: Props) {
+  console.log(areaBasedList);
+  // 카카오맵 URL 생성기
+  const getKakaoMapsUrl = (address: string) => {
+    return `https://map.kakao.com/link/search/${encodeURIComponent(address)}`;
+  };
+
+  return (
+    <section className="mx-auto px-4 py-12 max-w-5xl">
+      <h2 className="text-3xl font-bold mb-10 text-center">{area} 추천 음식점</h2>
+      <div className="space-y-6">
+        {areaBasedList.map((shop, index) => (
+          <div
+            key={index}
+            className="flex items-center gap-6 p-4 rounded-2xl bg-white shadow hover:shadow-md transition hover:scale-105"
+          >
+            <div className="w-24 h-24 flex-shrink-0 rounded-xl overflow-hidden bg-gray-200">
+              {shop.firstimage ? (
+                <img src={shop.firstimage} alt={shop.imgname} className="w-full h-full object-cover" />
+              ) : (
+                <div className="flex items-center justify-center w-full h-full bg-gray-100 text-gray-500 text-sm">
+                  이미지 없음
+                </div>
+              )}
+            </div>
+
+            <div className="flex-1">
+              <h3 className="text-xl font-semibold flex items-center gap-2 mb-1">
+                <FaStore className="text-pink-500" />
+                {shop.title}
+              </h3>
+              <p className="text-gray-600 mb-2">{shop.tel}</p>
+              <a
+                href={getKakaoMapsUrl(shop.addr1!)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center text-sm text-blue-500 hover:underline"
+              >
+                <FaMapMarkerAlt className="mr-1" />
+                {shop.addr1}
+              </a>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/week/page.tsx
+++ b/src/app/week/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Layout from "@/components/Layout";
+import useThemeMode from "@/hooks/useDarkMode";
+import Course from "./_components/Course";
+import GoodPrice from "./_components/GoodPirce";
+import Event from "./_components/Event";
+import { useEffect, useState } from "react";
+import { tour } from "@/services/tour";
+import { AreaBasedList, AreaBasedListResponse, AreaCodeResponse, CountResponse } from "@/types/tourInfo";
+import getCurrentWeekNumber from "@/utils/getCurrentWeekNumber";
+import { getRandomInt } from "@/utils/getRandomInt";
+
+export default function RegionHighlights() {
+  const [courseList, setCourseList] = useState<AreaBasedList[]>([]); // contentTypeId 25
+  const [foodList, setFoodList] = useState<AreaBasedList[]>([]); // contentTypeId 39
+  const [eventList, setEventList] = useState<AreaBasedList[]>([]); // contentTypeId 15
+  const [area, setArea] = useState("");
+
+  useEffect(() => {
+    const fetch = async () => {
+      const displayCount = 3;
+
+      const areaCodeResponse: AreaCodeResponse = await tour.getAreaCode();
+      const areaCode = areaCodeResponse.response.body.items.item;
+      const weekNumber = getCurrentWeekNumber();
+      const index = weekNumber % areaCode.length;
+
+      setArea(areaCode[index].name);
+
+      // 여행 코스 (contentTypeId: 25)
+      const courseCountRes: CountResponse = await tour.getAreaBasedList({
+        listYN: "N",
+        areaCode: areaCode[index].code,
+        contentTypeId: "25",
+        arrange: "O",
+      });
+      const courseTotalCount = courseCountRes.response.body.items.item[0].totalCnt;
+      const randomCoursePage = getRandomInt(0, Math.max(1, Math.floor(courseTotalCount / displayCount)));
+      const courseRes: AreaBasedListResponse = await tour.getAreaBasedList({
+        numOfRows: displayCount,
+        pageNo: randomCoursePage,
+        areaCode: areaCode[index].code,
+        contentTypeId: "25",
+        arrange: "O",
+      });
+      setCourseList(courseRes.response.body.items.item);
+
+      // 음식점/가성비 업소 (contentTypeId: 39)
+      const foodCountRes: CountResponse = await tour.getAreaBasedList({
+        listYN: "N",
+        areaCode: areaCode[index].code,
+        contentTypeId: "39",
+        arrange: "O",
+      });
+      const foodTotalCount = foodCountRes.response.body.items.item[0].totalCnt;
+      const randomFoodPage = getRandomInt(0, Math.max(1, Math.floor(foodTotalCount / displayCount)));
+      const foodRes: AreaBasedListResponse = await tour.getAreaBasedList({
+        numOfRows: displayCount,
+        pageNo: randomFoodPage,
+        areaCode: areaCode[index].code,
+        contentTypeId: "39",
+        arrange: "O",
+      });
+      setFoodList(foodRes.response.body.items.item);
+
+      // 지역 이벤트/행사 (contentTypeId: 15)
+      const eventCountRes: CountResponse = await tour.getAreaBasedList({
+        listYN: "N",
+        areaCode: areaCode[index].code,
+        contentTypeId: "15",
+        arrange: "O",
+      });
+      const eventTotalCount = eventCountRes.response.body.items.item[0].totalCnt;
+      const randomEventPage = getRandomInt(0, Math.max(1, Math.floor(eventTotalCount / displayCount)));
+      const eventRes: AreaBasedListResponse = await tour.getAreaBasedList({
+        numOfRows: displayCount,
+        pageNo: randomEventPage,
+        areaCode: areaCode[index].code,
+        contentTypeId: "15",
+        arrange: "O",
+      });
+      setEventList(eventRes.response.body.items.item);
+    };
+
+    fetch();
+  }, []);
+
+  const { themeMode } = useThemeMode();
+
+  const backgroundGradient = {
+    original: "from-pink-50 to-white",
+    light: "from-blue-50 to-white",
+    dark: "from-gray-900 to-gray-800",
+  };
+
+  const containerClassName = `py-16 min-h-screen relative overflow-hidden bg-gradient-to-b ${backgroundGradient[themeMode]}`;
+
+  return (
+    <Layout>
+      <div className={containerClassName}>
+        <Course areaBasedList={courseList} area={area} />
+        <GoodPrice areaBasedList={foodList} area={area} />
+        <Event areaBasedList={eventList} area={area} />
+      </div>
+    </Layout>
+  );
+}

--- a/src/components/common/NavSection.tsx
+++ b/src/components/common/NavSection.tsx
@@ -253,10 +253,10 @@ const NavSection = () => {
         </div>
 
         <div className="flex items-center gap-1 md:gap-3">
-          <Link
-            href="/festival"
-            className="hidden md:block text-gray-600 text-sm font-medium hover:text-gray-900 px-3 py-2 rounded-full hover:bg-gray-50 transition-colors"
-          >
+          <Link href="/week" className={getLinkClasses()}>
+            주간 여행지
+          </Link>
+          <Link href="/festival" className={getLinkClasses()}>
             축제
           </Link>
           <Link href="/recommendation" className={getLinkClasses()}>

--- a/src/services/tour.ts
+++ b/src/services/tour.ts
@@ -1,0 +1,76 @@
+import { AreaBasedListParams, AreaCodeParams } from "@/types/tourInfo";
+
+export const tour = {
+  getAreaBasedList: async (customParams?: Partial<AreaBasedListParams>) => {
+    const url = new URL(process.env.NEXT_PUBLIC_TOUR_API_BASE_URL + "/areaBasedList1");
+
+    // 기본 params
+    const defaultParams: AreaBasedListParams = {
+      numOfRows: 2000,
+      pageNo: 1,
+      MobileOS: "ETC",
+      MobileApp: process.env.NEXT_PUBLIC_SERVICE_NAME!,
+      _type: "json",
+      listYN: "Y",
+      serviceKey: process.env.NEXT_PUBLIC_TOUR_API_KEY!,
+    };
+
+    // 기본 params에 customParams를 덮어씀
+    const finalParams = { ...defaultParams, ...customParams };
+
+    Object.entries(finalParams).forEach(([key, value]) => {
+      if (value !== undefined) {
+        url.searchParams.append(key, value.toString());
+      }
+    });
+
+    const res = await fetch(url.toString(), {
+      next: {
+        tags: ["area", "based", "list"],
+        revalidate: 60 * 60 * 24 * 7, // 7일 캐싱
+      },
+      cache: "force-cache",
+    });
+
+    if (!res.ok) throw new Error("Failed to fetch area based list data");
+
+    return await res.json();
+  },
+
+  getAreaCode: async (customParams?: Partial<AreaCodeParams>) => {
+    const url = new URL(process.env.NEXT_PUBLIC_TOUR_API_BASE_URL + "/areaCode1");
+
+    // 기본 params
+    const defaultParams: AreaCodeParams = {
+      numOfRows: 20,
+      pageNo: 1,
+      MobileOS: "ETC",
+      MobileApp: process.env.NEXT_PUBLIC_SERVICE_NAME!,
+      _type: "json",
+      serviceKey: process.env.NEXT_PUBLIC_TOUR_API_KEY!,
+    };
+
+    // 기본 params에 customParams를 덮어씀
+    const finalParams = { ...defaultParams, ...customParams };
+
+    Object.entries(finalParams).forEach(([key, value]) => {
+      if (value !== undefined) {
+        url.searchParams.append(key, value.toString());
+      }
+    });
+
+    const res = await fetch(url.toString(), {
+      next: {
+        tags: ["area", "code"],
+        revalidate: 60 * 60 * 24 * 7, // 7일 캐싱
+      },
+      cache: "force-cache",
+    });
+
+    if (!res.ok) throw new Error("Failed to fetch area based list data");
+
+    return await res.json();
+  }
+
+
+}

--- a/src/types/tourInfo.ts
+++ b/src/types/tourInfo.ts
@@ -1,0 +1,69 @@
+export interface BaseParams {
+  numOfRows?: number;
+  pageNo?: number;
+  MobileOS: "IOS" | "AND" | "WIN" | "ETC";
+  MobileApp: string;
+  serviceKey: string;
+  _type?: "json" | "xml";
+}
+
+export interface AreaBasedListParams extends BaseParams {
+  listYN?: "Y" | "N"; // 목록구분(Y=목록, N=개수)
+  arrange?: "A" | "C" | "D" | "O" | "Q" | "R"; // 정렬구분 (A=제목순, C=수정일순, D=생성일순) 대표이미지가반드시있는정렬(O=제목순, Q=수정일순, R=생성일순)
+  contentTypeId?: string; // 관광타입(12:관광지, 14:문화시설, 15:축제공연행사, 25:여행코스, 28:레포츠, 32:숙박, 38:쇼핑, 39:음식점) ID
+  areaCode?: string // 지역코드(지역코드조회 참고)
+  sigunguCode?: string; // 시군구코드(지역코드조회 참고)
+  cat1?: string; // 대분류(서비스분류코드조회 참고)
+  cat2?: string; // 중분류(서비스분류코드조회 참고)
+  cat3?: string; // 소분류(서비스분류코드조회 참고)
+  modifiedtime?: string; // 수정일(형식 :YYYYMMDD)
+}
+
+export interface AreaCodeParams extends BaseParams {
+  areaCode?: string // 지역코드(지역코드조회 참고)
+}
+
+export interface TatalCnt {
+  totalCnt: number, // 콘텐츠 개수
+}
+
+export interface AreaBasedList {
+  contentid: string, // 콘텐츠ID
+  imgname: string, // 이미지명
+  originimgurl: string, // 원본이미지 (약 500*333 size)
+  serialnum: string, // 이미지일련번호
+  smallimageurl: string, // 썸네일이미지 (약 160*100 size)
+  cpyrhtDivCd: string // 저작권 유형 
+  firstimage?: string;
+  firstimage2?: string;
+  title?: string;
+  addr1?: string;
+  tel?: string;
+}
+
+export interface AreaCode {
+  code: string,
+  name: string,
+  rnum: string,
+}
+
+export interface Response<T> {
+  response: {
+    header: {
+      resultCode: string;
+      resultMsg: string;
+    }
+    body: {
+      items: {
+        item: T;
+      }
+      numOfRows: number;
+      pageNo: number;
+      totalCount: number; // 전체결과수
+    }
+  }
+}
+
+export type CountResponse = Response<TatalCnt[]>;
+export type AreaBasedListResponse = Response<AreaBasedList[]>;
+export type AreaCodeResponse = Response<AreaCode[]>;

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -68,3 +68,9 @@ export function getDaysForMonth(year: number, month: number): string[] {
 
   return days;
 }
+
+export function formatDateDot(dateStr?: string) {
+  if (!dateStr) return "";
+  if (dateStr.length !== 8) return dateStr;
+  return `${dateStr.substring(0, 4)}.${dateStr.substring(4, 6)}.${dateStr.substring(6, 8)}`;
+}

--- a/src/utils/getCurrentWeekNumber.ts
+++ b/src/utils/getCurrentWeekNumber.ts
@@ -1,0 +1,6 @@
+export default function getCurrentWeekNumber() {
+  const now = new Date();
+  const startOfYear = new Date(now.getFullYear(), 0, 1);
+  const pastDaysOfYear = (now.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000);
+  return Math.ceil((pastDaysOfYear + startOfYear.getDay() + 1) / 7);
+}

--- a/src/utils/getRandomInt.ts
+++ b/src/utils/getRandomInt.ts
@@ -1,0 +1,2 @@
+export const getRandomInt = (min: number, max: number) =>
+    Math.floor(Math.random() * (max - min + 1)) + min;


### PR DESCRIPTION
## 변경 사항 요약

- Nav에 주간 여행지 탭 추가
- 주간 여행지 페이지 생성

## 관련 이슈

-  Closes #56 

## 변경 상세 내용

- 매주 주간 여행지가 달라짐.
  현재 이번년도의 몇번째 주 % 지역 배열의 길이

- 코스
  현재는 아무 기능 없음

- 음식점
  고도화: 착한 가격 업소 api 가 있다면 추후 추가

- 이벤트
  클릭시 축제 디테일 페이지로 이동

## 테스트 방법

- 변경 사항을 검증하기 위한 테스트 방법과 환경을 설명합니다.
- 수동 테스트 시나리오나 자동화 테스트 결과를 함께 기입할 수 있습니다.

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 모든 테스트 통과
- [ ] 문서 및 주석 업데이트 완료 (해당 시)

## 기타 참고 사항

- 추가로 참고할 자료나 설명이 필요한 경우 기입합니다.
