### PR TITLE
feat: 축제 달력/리스트 키워드 검색 기능 구현

### DIFF
--- a/src/app/festival/(with-nav)/calendar/page.tsx
+++ b/src/app/festival/(with-nav)/calendar/page.tsx
@@ -16,6 +16,9 @@ export default function Calendar() {
   const today = new Date();
   const [currentMonthIndex, setCurrentMonthIndex] = useState(0);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [submittedQuery, setSubmittedQuery] = useState(""); // 🔥 확정된 검색어
+  const [suggestions, setSuggestions] = useState<string[]>([]);
 
   const { data, isLoading, error } = useQuery<FestivalResponse>({
     queryKey: ["festivals"],
@@ -30,7 +33,7 @@ export default function Calendar() {
   const year = new Date(baseYear, baseMonth + currentMonthIndex).getFullYear();
   const month = new Date(baseYear, baseMonth + currentMonthIndex).getMonth() + 1;
 
-  const allDays = getDaysForMonth(year, month); // number | null
+  const allDays = getDaysForMonth(year, month);
   const weeks = [];
   for (let i = 0; i < allDays.length; i += 7) {
     weeks.push(allDays.slice(i, i + 7));
@@ -48,12 +51,47 @@ export default function Calendar() {
     setSelectedDate(dateStr === selectedDate ? null : dateStr);
   };
 
-  const selectedFestivals = sortedItems?.filter(
-    (item) =>
-      selectedDate &&
-      item.eventstartdate <= selectedDate &&
-      selectedDate <= item.eventenddate
-  );
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchTerm(value);
+
+    if (value.length > 0) {
+      const filteredSuggestions = sortedItems
+        ?.map((festival) => festival.title)
+        .filter((title) => title.toLowerCase().includes(value.toLowerCase()))
+        .slice(0, 5);
+      setSuggestions(filteredSuggestions || []);
+    } else {
+      setSuggestions([]);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      setSubmittedQuery(searchTerm.trim());
+      setSuggestions([]);
+    }
+  };
+
+  const handleSuggestionClick = (suggestion: string) => {
+    setSearchTerm(suggestion);
+    setSubmittedQuery(suggestion);
+    setSuggestions([]);
+  };
+
+  const filteredFestivals = sortedItems?.filter((festival) => {
+    const title = festival.title?.toLowerCase() || "";
+    const addr = festival.addr1?.toLowerCase() || "";
+    const keyword = submittedQuery.toLowerCase();
+
+    const matchesSearch = title.includes(keyword) || addr.includes(keyword);
+    const matchesDate =
+      !selectedDate ||
+      (festival.eventstartdate <= selectedDate && selectedDate <= festival.eventenddate);
+
+    return matchesSearch && matchesDate;
+  });
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
@@ -83,23 +121,14 @@ export default function Calendar() {
 
       {/* 달력 */}
       <div className="rounded-xl border border-purple-200 overflow-hidden shadow-sm">
-        {/* 요일 헤더 */}
         <div className="grid grid-cols-7 bg-purple-50 text-center text-sm font-bold text-gray-700">
           {days.map((day, i) => (
-            <div
-              key={day}
-              className={clsx(
-                "py-3",
-                i === 0 && "text-red-500",
-                i === 6 && "text-blue-500"
-              )}
-            >
+            <div key={day} className={clsx("py-3", i === 0 && "text-red-500", i === 6 && "text-blue-500")}>
               {day}
             </div>
           ))}
         </div>
 
-        {/* 날짜 셀 */}
         <div className="grid grid-cols-7 border-t border-purple-200 bg-white">
           {weeks.map((week, weekIdx) =>
             week.map((day, i) => {
@@ -131,12 +160,7 @@ export default function Calendar() {
                 >
                   {isValidDay && (
                     <>
-                      <span
-                        className={clsx(
-                          "font-bold text-base",
-                          isSelected ? "text-purple-700" : "text-gray-800"
-                        )}
-                      >
+                      <span className={clsx("font-bold text-base", isSelected ? "text-purple-700" : "text-gray-800")}>
                         {day}
                       </span>
                       <span className="text-xs text-purple-500 mt-1">{count}개</span>
@@ -152,56 +176,82 @@ export default function Calendar() {
 
       {/* 축제 리스트 */}
       <div className="mt-10">
-        <h3 className="text-2xl font-bold mb-6 text-gray-800">
-          {selectedDate
-            ? `${selectedDate.slice(0, 4)}년 ${selectedDate.slice(4, 6)}월 ${selectedDate.slice(6, 8)}일의 축제 리스트`
-            : "날짜를 선택해 축제를 확인해보세요!"}
-        </h3>
+        <div className="flex flex-col md:flex-row justify-between items-center mb-6 gap-3">
+          <h3 className="text-2xl font-bold text-gray-800">
+            {submittedQuery
+              ? `"${submittedQuery}" 검색 결과`
+              : selectedDate
+              ? `${selectedDate.slice(0, 4)}년 ${selectedDate.slice(4, 6)}월 ${selectedDate.slice(6, 8)}일의 축제 리스트`
+              : "전체 축제 리스트"}
+          </h3>
+
+          <div className="w-full md:w-96 relative">
+            <input
+              type="text"
+              placeholder="축제 이름이나 장소 검색"
+              value={searchTerm}
+              onChange={handleSearchChange}
+              onKeyDown={handleKeyDown}
+              className="w-full px-4 py-2 border border-gray-300 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-400 transition"
+            />
+            {suggestions.length > 0 && (
+              <ul className="absolute z-[9999] w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
+                {suggestions.map((suggestion, index) => (
+                  <li
+                    key={index}
+                    onClick={() => handleSuggestionClick(suggestion)}
+                    className="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+                  >
+                    {suggestion}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
 
         <AnimatePresence mode="wait">
-          {selectedDate && (
-            <motion.div
-              key={selectedDate}
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.3 }}
-              className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"
-            >
-              {selectedFestivals?.map((item) => (
-                <div
-                  key={item.contentid}
-                  className="relative bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm hover:shadow-md transition cursor-pointer"
-                  onClick={() =>
-                    router.push(`/festival/detail/${item.contentid}`, { scroll: false })
-                  }
-                >
-                  <div className="absolute top-2 left-2 bg-purple-500 text-white text-xs font-semibold px-2 py-1 rounded z-10">
-                    개최중
-                  </div>
-                  <img
-                    src={item.firstimage || "/placeholder.jpg"}
-                    alt={item.title}
-                    className="w-full h-48 object-cover"
-                  />
-                  <div className="p-4">
-                    <h3 className="text-base font-bold text-gray-800 line-clamp-2">{item.title}</h3>
-                    <p className="text-sm text-gray-600 mt-1">
-                      {item.eventstartdate} ~ {item.eventenddate}
-                    </p>
-                    <p className="text-sm text-gray-500">
-                      {item.addr1 || "장소 정보 없음"}
-                    </p>
-                  </div>
+          <motion.div
+            key={selectedDate || "all"}
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.3 }}
+            className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"
+          >
+            {filteredFestivals?.map((item) => (
+              <div
+                key={item.contentid}
+                className="relative bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm hover:shadow-md transition cursor-pointer"
+                onClick={() =>
+                  router.push(`/festival/detail/${item.contentid}`, { scroll: false })
+                }
+              >
+                <div className="absolute top-2 left-2 bg-purple-500 text-white text-xs font-semibold px-2 py-1 rounded z-10">
+                  개최중
                 </div>
-              ))}
-              {selectedFestivals?.length === 0 && (
-                <p className="text-gray-500 text-center col-span-3">
-                  해당 날짜에 축제가 없습니다.
-                </p>
-              )}
-            </motion.div>
-          )}
+                <img
+                  src={item.firstimage || "/placeholder.jpg"}
+                  alt={item.title}
+                  className="w-full h-48 object-cover"
+                />
+                <div className="p-4">
+                  <h3 className="text-base font-bold text-gray-800 line-clamp-2">{item.title}</h3>
+                  <p className="text-sm text-gray-600 mt-1">
+                    {item.eventstartdate} ~ {item.eventenddate}
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    {item.addr1 || "장소 정보 없음"}
+                  </p>
+                </div>
+              </div>
+            ))}
+            {filteredFestivals?.length === 0 && (
+              <p className="text-gray-500 text-center col-span-3">
+                해당 조건의 축제가 없습니다.
+              </p>
+            )}
+          </motion.div>
         </AnimatePresence>
       </div>
     </div>

--- a/src/app/festival/(with-nav)/list/page.tsx
+++ b/src/app/festival/(with-nav)/list/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import getFestivals from "../../_services/getFestivals";
 import { FestivalResponse } from "@/types/festival";
@@ -7,6 +8,10 @@ import Card from "../../_components/Card";
 import { getDate } from "@/utils/dateUtils";
 
 export default function FestivalList() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [submittedQuery, setSubmittedQuery] = useState(""); // Enter나 클릭 시 확정된 검색어
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
   const { data, isLoading, error } = useQuery<FestivalResponse>({
     queryKey: ["festivals"],
     queryFn: getFestivals,
@@ -15,17 +20,101 @@ export default function FestivalList() {
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>에러 발생</div>;
 
-  const items = data?.response.body.items.item.filter((festival) => festival.eventenddate > getDate()); // 끝난 축제 필터링
-  const sortedItems = items?.sort((a, b) => Number(a.eventstartdate) - Number(b.eventstartdate)); // 이벤트 시작일 빠른순 정렬
+  const items = data?.response.body.items.item.filter(
+    (festival) => festival.eventenddate > getDate()
+  );
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchTerm(value);
+
+    if (value.length > 0) {
+      const filteredSuggestions = items
+        ?.map((festival) => festival.title)
+        .filter((title) => title.toLowerCase().includes(value.toLowerCase()))
+        .slice(0, 5);
+      setSuggestions(filteredSuggestions || []);
+    } else {
+      setSuggestions([]);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (searchTerm.trim() !== "") {
+        setSubmittedQuery(searchTerm.trim());
+        setSuggestions([]);
+      }
+    }
+  };
+
+  const handleSuggestionClick = (suggestion: string) => {
+    setSearchTerm(suggestion);
+    setSubmittedQuery(suggestion);
+    setSuggestions([]);
+  };
+
+  // 필터된 축제 목록 (검색어가 있을 경우)
+  const filteredItems = submittedQuery
+    ? items?.filter((festival) =>
+        [festival.title, festival.addr1]
+          .join(" ")
+          .toLowerCase()
+          .includes(submittedQuery.toLowerCase())
+      )
+    : items;
+
+  const sortedItems = filteredItems?.sort(
+    (a, b) => Number(a.eventstartdate) - Number(b.eventstartdate)
+  );
 
   return (
-    <div className="px-5 py-4 flex justify-center">
-      <ul className="max-w-screen-2xl list-none p-0 transition-all grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
+    <div className="px-5 py-4 flex flex-col items-center">
+      {/* 🔍 검색바 */}
+      <div className="mb-6 w-full max-w-2xl relative">
+        <input
+          type="text"
+          placeholder="축제 이름이나 장소를 검색하세요"
+          value={searchTerm}
+          onChange={handleSearchChange}
+          onKeyDown={handleKeyDown}
+          className="w-full px-4 py-3 border border-gray-300 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-400 transition"
+        />
+        {suggestions.length > 0 && (
+          <ul className="absolute z-[9999] w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto">
+            {suggestions.map((suggestion, index) => (
+              <li
+                key={index}
+                onClick={() => handleSuggestionClick(suggestion)}
+                className="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+              >
+                {suggestion}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* 검색어 결과 타이틀 */}
+      {submittedQuery && (
+        <h2 className="text-lg font-semibold mb-4 text-purple-700">
+          “{submittedQuery}” 검색 결과
+        </h2>
+      )}
+
+      {/* 축제 리스트 */}
+      <ul className="w-full max-w-screen-2xl list-none p-0 transition-all grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
         {sortedItems?.map((festival) => (
           <li key={festival.contentid}>
             <Card festival={festival} />
           </li>
         ))}
+        {sortedItems?.length === 0 && (
+          <li className="col-span-full text-center text-gray-500 mt-4">
+            검색 결과가 없습니다.
+          </li>
+        )}
       </ul>
     </div>
   );


### PR DESCRIPTION
변경 사항 요약

- 축제 리스트 페이지 및 달력 페이지 상단에 검색 기능(Search Bar) 추가
- 추천 키워드 자동완성 기능 구현 (최대 5개 노출)
- 키워드 입력 후 Enter 시 `"키워드" 검색 결과`로 타이틀 표시
- 캘린더 페이지는 날짜 미선택 시 전체 축제 노출, 선택 시 해당 날짜의 축제만 필터링
- 추천 키워드 클릭 시에도 동일하게 검색 필터 적용

체크리스트

- [x] 축제 리스트 페이지 상단 검색창 구현
- [x] 자동완성 키워드 기능 구현
- [x] 키워드 입력 후 Enter 시 결과 필터링 동작 확인
- [x] 캘린더 페이지에서도 동일한 검색 기능 적용
- [x] 날짜 미선택 시 전체 축제 리스트 출력
- [x] UI 반응형 동작 및 레이아웃 이상 없음 확인
- [x] 기존 기능과의 충돌 없음