### PR TITLE
fix: 리뷰 API 및 코스 데이터 처리 개선, 찜하기 기능 추가

### DIFF
--- a/src/app/api/reviews/[id]/route.ts
+++ b/src/app/api/reviews/[id]/route.ts
@@ -9,11 +9,11 @@ if (!SERVER_BASE_URL) {
 // GET 요청 처리 - 특정 리뷰 상세 조회
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = await params;
-    
+    const { id } = params;
+
     if (!id) {
       return NextResponse.json(
         { error: '리뷰 ID가 필요합니다.' },
@@ -29,8 +29,8 @@ export async function GET(
       'Content-Type': 'application/json',
     };
 
-    // Authorization 헤더 추가 (쿠키에서 가져오기)
-    const authorization = request.headers.get('Authorization');
+    // Authorization 헤더 추가 (케이스 통일)
+    const authorization = request.headers.get('authorization');
     if (authorization) {
       headers['Authorization'] = authorization;
       console.log('✅ Authorization 헤더 전달');
@@ -47,40 +47,27 @@ export async function GET(
     console.log(`📋 응답 헤더 Content-Type: ${response.headers.get('content-type')}`);
 
     if (!response.ok) {
-      // 응답 내용을 텍스트로 확인
+      // 401 또는 404 오류인 경우 null 반환 (클라이언트에서 not-found 처리)
+      if (response.status === 401 || response.status === 404) {
+        return NextResponse.json(null, { status: 200 });
+      }
+
       const responseText = await response.text();
       console.error(`❌ 서버 API 오류: ${response.status} ${response.statusText}`);
       console.error(`❌ 응답 내용: ${responseText.substring(0, 200)}...`);
-      
-      // 401 또는 404 오류인 경우 null 반환 (임시 처리)
-      if (response.status === 401 || response.status === 404) {
-        return NextResponse.json(null);
-      }
-      
       return NextResponse.json(
         { error: '서버에서 리뷰를 가져오는 중 오류가 발생했습니다.' },
         { status: response.status }
       );
     }
 
-    // 응답 내용을 먼저 텍스트로 확인
-    const responseText = await response.text();
-    console.log(`✅ 서버 응답 내용 (처음 200자): ${responseText.substring(0, 200)}...`);
-    
-    try {
-      const data = JSON.parse(responseText);
-      console.log(`✅ JSON 파싱 성공`);
-      return NextResponse.json(data);
-    } catch (parseError) {
-      console.error(`❌ JSON 파싱 실패:`, parseError);
-      console.error(`❌ 파싱 실패한 응답: ${responseText.substring(0, 500)}...`);
-      return NextResponse.json(null);
-    }
+    // 안전하게 JSON으로 바로 파싱
+    const data = await response.json();
+    return NextResponse.json(data, { status: 200 });
   } catch (error) {
     console.error('💥 리뷰 상세 API 프록시 오류:', error);
-    
-    // 오류 발생 시 null 반환 (임시 처리)
-    return NextResponse.json(null);
+    // 오류 발생 시에도 null 반환하여 클라이언트에서 처리
+    return NextResponse.json(null, { status: 200 });
   }
 }
 

--- a/src/app/popular-courses/page.tsx
+++ b/src/app/popular-courses/page.tsx
@@ -20,6 +20,7 @@ import { BsArrowUpRight } from "react-icons/bs";
 import NavSection from "@/components/common/NavSection";
 import Footer from "@/components/common/Footer";
 import useThemeMode from "@/hooks/useDarkMode";
+import { courseApi } from "@/services/courseService";
 
 // 정확히 표시할 코스 개수
 const COURSE_COUNT = 16;
@@ -35,48 +36,12 @@ interface Course {
   rating?: number;
 }
 
-// 이미지 크기 확인 함수
-function isImageLargeEnough(url: string) {
-  return new Promise<boolean>((resolve) => {
-    // HTMLImageElement 사용으로 타입 문제 해결
-    const img = document.createElement("img");
-    img.onload = () => {
-      if (img.width >= 300 && img.height >= 300) {
-        resolve(true);
-      } else {
-        resolve(false);
-      }
-    };
-    img.onerror = () => resolve(false);
-    img.src = url;
-  });
-}
-
-// 유효한 이미지를 가진 코스만 필터링하는 함수
-async function filterValidImages(courses: Course[]) {
-  const filtered = [];
-  const imageUrls = new Set(); // 이미지 URL 중복 체크를 위한 Set
-
-  for (const course of courses) {
-    // 이미지 URL이 이미 사용되었는지 확인
-    if (imageUrls.has(course.thumbnailUrl)) {
-      console.log(`중복 이미지 발견: ${course.thumbnailUrl}, 코스 제외: ${course.title}`);
-      continue;
-    }
-
-    const valid = await isImageLargeEnough(course.thumbnailUrl);
-    if (valid) {
-      filtered.push(course);
-      imageUrls.add(course.thumbnailUrl); // 사용된 이미지 URL 추가
-    }
-  }
-
-  return filtered;
-}
+// 성능 최적화를 위해 이미지 선검증을 제거하고, 렌더 단계에서 fallback 이미지를 사용합니다.
 
 // API에서 코스 데이터를 가져오는 함수
 async function fetchCourseData(page = 0, limit = 50) {
-  const response = await fetch(`http://localhost:8080/api/course?page=${page}&limit=${limit}`, {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://3.34.52.239:8080';
+  const response = await fetch(`${baseUrl}/api/course?page=${page}&limit=${limit}`, {
     mode: "cors",
     cache: "no-store",
   });
@@ -89,64 +54,10 @@ async function fetchCourseData(page = 0, limit = 50) {
   return Array.isArray(data) ? data : [];
 }
 
-// 필요한 갯수만큼 유효한 코스를 가져오는 함수
-async function fetchValidCoursesUntilThreshold(threshold = COURSE_COUNT, maxAttempts = 30) {
-  let validCourses: Course[] = [];
-  let page = 0;
-  let attempts = 0;
-
-  // 유효한 코스가 threshold에 도달하거나 최대 시도 횟수에 도달할 때까지 반복
-  while (validCourses.length < threshold && attempts < maxAttempts) {
-    console.log(`시도 ${attempts + 1}: 현재 유효한 코스 ${validCourses.length}개, 목표 ${threshold}개`);
-
-    const newCourses = await fetchCourseData(page, 50);
-
-    if (newCourses.length === 0) {
-      console.log("더 이상 가져올 데이터가 없습니다.");
-      if (validCourses.length < threshold) {
-        console.log(`충분한 코스를 찾지 못했습니다. 현재 ${validCourses.length}개, 목표 ${threshold}개`);
-        // 더 많은 시도를 위해 페이지를 초기화하고 다시 시작
-        page = 0;
-      }
-      attempts++;
-      continue;
-    }
-
-    // 새로 가져온 코스에서 유효한 이미지만 필터링 (중복 제거)
-    const newValidCourses = await filterValidImages(newCourses);
-    console.log(`페이지 ${page}에서 ${newCourses.length}개 중 ${newValidCourses.length}개의 유효한 코스 발견`);
-
-    // 누적된 유효한 코스에 추가 (중복 체크)
-    for (const course of newValidCourses) {
-      // 이미 같은 코스 ID가 있는지 확인
-      if (!validCourses.some((c) => c.courseId === course.courseId)) {
-        validCourses.push(course);
-        if (validCourses.length >= threshold) {
-          break; // 목표 개수 달성
-        }
-      }
-    }
-    console.log(`누적된 유효한 코스: ${validCourses.length}개`);
-
-    page++;
-    attempts++;
-
-    // 페이지가 너무 많이 증가하면 다시 처음부터 시작
-    if (page > 10) {
-      page = 0;
-    }
-  }
-
-  if (validCourses.length < threshold) {
-    console.warn(
-      `최대 시도 횟수(${maxAttempts})에 도달했지만 ${threshold}개를 채우지 못했습니다. 현재 ${validCourses.length}개`
-    );
-  }
-
-  // 정확히 threshold 개수만큼만 반환
-  const result = validCourses.slice(0, threshold);
-  console.log(`최종 반환되는 유효한 코스: ${result.length}개`);
-  return result;
+// 단순히 첫 페이지에서 받아온 데이터 중 상위 N개만 사용합니다.
+async function fetchFirstPageCourses(threshold = COURSE_COUNT) {
+  const firstPage = await fetchCourseData(0, 50);
+  return firstPage.slice(0, threshold);
 }
 
 export default function PopularCoursesPage() {
@@ -172,16 +83,12 @@ export default function PopularCoursesPage() {
   const locationColor = themeMode === "original" ? "pink.500" : themeMode === "dark" ? "cyan.400" : "blue.600";
   const buttonHoverBg = themeMode === "original" ? "pink.600" : themeMode === "dark" ? "cyan.400" : "blue.600";
 
-  // 코스 데이터 가져오기
+  // 코스 데이터 가져오기 (간소화: 1회 요청)
   useEffect(() => {
     const loadCourses = async () => {
       try {
-        console.log("코스 로딩 시작...");
-        const validCourses = await fetchValidCoursesUntilThreshold(COURSE_COUNT);
-
-        // 정확히 16개만 설정
-        setCourses(validCourses.slice(0, COURSE_COUNT));
-        console.log(`최종 설정된 코스 수: ${validCourses.slice(0, COURSE_COUNT).length}`);
+        const list = await fetchFirstPageCourses(COURSE_COUNT);
+        setCourses(list);
 
         setIsLoading(false);
       } catch (err) {
@@ -194,51 +101,61 @@ export default function PopularCoursesPage() {
     loadCourses();
   }, []);
 
-  // 찜 목록 불러오기
+  // 찜 목록 불러오기 (로그인 시 서버, 비로그인 시 로컬)
   useEffect(() => {
-    const savedLikes = localStorage.getItem("likedCourses");
-    if (savedLikes) {
-      setLikedCourses(JSON.parse(savedLikes));
-    }
+    const initLikes = async () => {
+      const token = typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
+      if (token) {
+        try {
+          const liked = await courseApi.getLikedCourses();
+          setLikedCourses(liked.map((c) => c.courseId));
+          return;
+        } catch (e) {
+          // 서버 실패 시 로컬로 폴백
+        }
+      }
+      const savedLikes = typeof window !== "undefined" ? localStorage.getItem("likedCourses") : null;
+      if (savedLikes) setLikedCourses(JSON.parse(savedLikes));
+    };
+    initLikes();
   }, []);
 
-  // 찜하기 토글
-  const toggleLike = (courseId: number, e: React.MouseEvent) => {
+  // 찜하기 토글 (로그인 시 서버, 비로그인 시 로컬)
+  const toggleLike = async (courseId: number, e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
 
-    // if (!session) {
-    //   toast({
-    //     title: "로그인이 필요합니다",
-    //     description: "찜하기는 로그인 후 이용할 수 있습니다",
-    //     status: "warning",
-    //     duration: 3000,
-    //     isClosable: true,
-    //   });
-    //   return;
-    // }
+    const token = typeof window !== "undefined" ? sessionStorage.getItem("accessToken") : null;
+    if (token) {
+      try {
+        if (likedCourses.includes(courseId)) {
+          await courseApi.unlikeCourse(courseId);
+          setLikedCourses((prev) => prev.filter((id) => id !== courseId));
+          toast({ title: "찜 목록에서 제거되었습니다", status: "info", duration: 1500, isClosable: true });
+        } else {
+          await courseApi.courseLike(String(courseId));
+          setLikedCourses((prev) => [...prev, courseId]);
+          toast({ title: "찜 목록에 추가되었습니다", status: "success", duration: 1500, isClosable: true });
+        }
+      } catch (err) {
+        toast({ title: "찜하기 처리 중 오류가 발생했습니다", status: "error", duration: 2000, isClosable: true });
+      }
+      return;
+    }
 
+    // 비로그인: 로컬 스토리지로만 관리
     let newLikedCourses;
     if (likedCourses.includes(courseId)) {
       newLikedCourses = likedCourses.filter((id) => id !== courseId);
-      toast({
-        title: "찜 목록에서 제거되었습니다",
-        status: "info",
-        duration: 2000,
-        isClosable: true,
-      });
+      toast({ title: "찜 목록에서 제거되었습니다", status: "info", duration: 1500, isClosable: true });
     } else {
       newLikedCourses = [...likedCourses, courseId];
-      toast({
-        title: "찜 목록에 추가되었습니다",
-        status: "success",
-        duration: 2000,
-        isClosable: true,
-      });
+      toast({ title: "찜 목록에 추가되었습니다", status: "success", duration: 1500, isClosable: true });
     }
-
     setLikedCourses(newLikedCourses);
-    localStorage.setItem("likedCourses", JSON.stringify(newLikedCourses));
+    if (typeof window !== "undefined") {
+      localStorage.setItem("likedCourses", JSON.stringify(newLikedCourses));
+    }
   };
 
   useEffect(() => {
@@ -410,7 +327,14 @@ export default function PopularCoursesPage() {
               >
                 {/* 이미지 영역 - 비율 조정 */}
                 <Box position="relative" height="52%" overflow="hidden">
-                  <Image src={course.thumbnailUrl} alt={course.title} objectFit="cover" width="100%" height="100%" />
+                  <Image
+                    src={course.thumbnailUrl}
+                    alt={course.title}
+                    objectFit="cover"
+                    width="100%"
+                    height="100%"
+                    fallbackSrc="/images/popular/map_pin.png"
+                  />
                   {/* 지역 뱃지 - 이미지 위에 배치 */}
                   <Box
                     position="absolute"

--- a/src/app/travel/favorite-courses/_components/CourseCard.tsx
+++ b/src/app/travel/favorite-courses/_components/CourseCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Image, useColorModeValue, chakra } from "@chakra-ui/react";
+import { Box, Image, useColorModeValue, chakra, Badge, Flex, Tooltip } from "@chakra-ui/react";
 import { Course, Destination } from "@/types";
 import { getCityImage } from "@/utils/imageUtils";
 
@@ -8,33 +8,60 @@ interface Props {
   course: Course;
   destination: Destination;
   index?: number;
+  onClick?: () => void;
 }
 
-export default function CourseCard({ course, destination, index }: Props) {
+export default function CourseCard({ course, destination, index, onClick }: Props) {
   const isNew = true;
+  const handleKakaoShare = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      const kakao: any = (window as any).Kakao;
+      const pageUrl = `${window.location.origin}/travel/popular/${course.courseId}`;
+      const imageUrl = destination.destinationThumbnailImageUrl || course.thumbnailUrl || '';
+      if (kakao && kakao.isInitialized && kakao.isInitialized()) {
+        kakao.Share.sendDefault({
+          objectType: 'feed',
+          content: {
+            title: course.title,
+            description: destination.destinationAddr1 || course.area,
+            imageUrl: imageUrl || `${window.location.origin}/images/popular/map_pin.png`,
+            link: { mobileWebUrl: pageUrl, webUrl: pageUrl },
+          },
+          buttons: [
+            { title: '자세히 보기', link: { mobileWebUrl: pageUrl, webUrl: pageUrl } },
+          ],
+        });
+      } else if (navigator.share) {
+        navigator.share({ title: course.title, text: '여행 코스 공유', url: pageUrl }).catch(() => {});
+      } else {
+        navigator.clipboard.writeText(pageUrl).catch(() => {});
+      }
+    } catch {}
+  };
 
   return (
     <Box
       bg={useColorModeValue("white", "gray.700")}
-      borderWidth="1px"
-      borderLeftWidth="4px"
-      borderLeftColor="purple.400"
-      rounded="lg"
-      shadow="md"
+      borderWidth="0"
+      rounded="2xl"
       overflow="hidden"
       position="relative"
-      minHeight="380px"
+      minHeight="420px"
       display="flex"
       flexDirection="column"
       justifyContent="space-between"
-      _hover={{
-        shadow: "lg",
-        transform: "translateY(-4px)",
-        transition: "0.2s",
-      }}
+      cursor={onClick ? 'pointer' : 'default'}
+      onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      transition="box-shadow .2s, transform .2s, border-radius .2s"
+      boxShadow="0 6px 18px rgba(0,0,0,0.08)"
+      _hover={{ transform: "translateY(-4px)", boxShadow: "0 14px 32px rgba(0,0,0,0.14)" }}
     >
       {/* 썸네일: destination의 이미지 사용 */}
-      <Image
+      <Box position="relative">
+        <Image
         src={
           destination.destinationThumbnailImageUrl ||
           course.thumbnailUrl ||
@@ -42,20 +69,46 @@ export default function CourseCard({ course, destination, index }: Props) {
         }
         alt={course.title}
         objectFit="cover"
-        w="100%"
-        h="300px"
-      />
+          w="100%"
+          h="240px"
+          borderTopLeftRadius="16px"
+          borderTopRightRadius="16px"
+          fallbackSrc="/images/popular/map_pin.png"
+        />
+        {/* 좌상단 지역 뱃지 */}
+        <Badge position="absolute" top="3" left="3" colorScheme="pink" rounded="full" px={3} py={1} fontWeight="600" boxShadow="0 2px 6px rgba(0,0,0,0.12)">
+          {`#${course.area}`}
+        </Badge>
+        {/* 우상단 카카오 공유 로고 (프레임 없이 아이콘만) */}
+        <Tooltip label="카카오톡으로 공유" hasArrow>
+          <chakra.img
+            src="/icons/kakao-talk.png"
+            alt="카카오톡 공유"
+            onClick={handleKakaoShare}
+            position="absolute"
+            top="10px"
+            right="10px"
+            width="36px"
+            height="36px"
+            cursor="pointer"
+            style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.25))' }}
+          />
+        </Tooltip>
+      </Box>
       {/* 카드 본문 */}
-      <Box p="4" height="150px">
+      <Box px="5" pt="4" pb="6">
         <chakra.h3
-          fontSize="1.5em"
-          fontWeight="bold"
+          fontSize="lg"
+          fontWeight="700"
           noOfLines={2}
           mb="2"
-          color="teal.400"
+          color={useColorModeValue('gray.900','white')}
         >
           {course.title}
         </chakra.h3>
+        <chakra.p fontSize="sm" color="gray.600" noOfLines={1}>
+          {destination.destinationAddr1 || destination.destinationName}
+        </chakra.p>
       </Box>
     </Box>
   );

--- a/src/app/travel/favorite-courses/page.tsx
+++ b/src/app/travel/favorite-courses/page.tsx
@@ -5,7 +5,7 @@ import Layout from "@/components/Layout";
 import Script from "next/script";
 import { useRouter } from "next/navigation";
 import BannerSlider from "./_components/BannerSlider";
-import { SimpleGrid, Flex, IconButton, useToast } from "@chakra-ui/react";
+import { SimpleGrid, Flex, IconButton, useToast, Box } from "@chakra-ui/react";
 import { Course, Destination } from "@/types";
 import { courseApi } from "@/services/courseService";
 import { destinationApi } from "@/services/destinationService";
@@ -70,17 +70,26 @@ function LikedCoursesList({
       )}
 
       {/* 카드 리스트 */}
-      <SimpleGrid columns={[1, 2, 3]} spacing={4} flex="1">
+      <SimpleGrid
+        columns={[1, 2, 3]}
+        spacingX={{ base: 6, md: 12, lg: 20 }}
+        spacingY={{ base: 8, md: 12, lg: 16 }}
+        flex="1"
+      >
         {visibleCourses.map((course) => {
           const dest = destinations.find(
             (d) => d.destinationContentId === course.contentId
           );
           return dest ? (
-            <CourseCard
-              key={course.courseId}
-              course={course}
-              destination={dest}
-            />
+            <Box key={course.courseId} mx={{ base: 3, md: 4, lg: 5 }} mb={{ base: 6, md: 8 }}>
+              <CourseCard
+                course={course}
+                destination={dest}
+                onClick={() => {
+                  window.location.href = `/travel/popular/${course.courseId}`;
+                }}
+              />
+            </Box>
           ) : null;
         })}
       </SimpleGrid>
@@ -124,6 +133,55 @@ export default function FavoriteCoursesPage() {
   >([]);
   const [start, setStart] = useState<Destination | null>(null);
 
+  // 지도 표시를 위한 좌표 준비
+  useEffect(() => {
+    if (!sdkReady || !destinations.length) return;
+    if (!window.kakao || !window.kakao.maps) return;
+
+    const container = document.getElementById('liked-courses-map');
+    if (!container) return;
+
+    window.kakao.maps.load(() => {
+      const options = {
+        center: new window.kakao.maps.LatLng(37.5665, 126.9780),
+        level: 7,
+      };
+      const map = new window.kakao.maps.Map(container, options);
+
+      const bounds = new window.kakao.maps.LatLngBounds();
+      destinations.forEach((d) => {
+        const latlng = new window.kakao.maps.LatLng(
+          Number(d.destinationLatitude),
+          Number(d.destinationLongitude)
+        );
+
+        // 해당 목적지와 매칭되는 코스 찾기 (contentId 기준)
+        const matchedCourse = likedCourses.find(
+          (c) => String(c.contentId) === String(d.destinationContentId)
+        );
+
+        const marker = new window.kakao.maps.Marker({
+          map,
+          position: latlng,
+          title: matchedCourse?.title || d.destinationName || '찜한 코스',
+        });
+
+        // 마커 클릭 시 코스 상세 페이지로 이동
+        if (matchedCourse) {
+          window.kakao.maps.event.addListener(marker, 'click', () => {
+            window.location.href = `/travel/popular/${matchedCourse.courseId}`;
+          });
+        }
+
+        bounds.extend(latlng);
+      });
+
+      if (!bounds.isEmpty()) {
+        map.setBounds(bounds);
+      }
+    });
+  }, [sdkReady, destinations, likedCourses]);
+
   // API가 Course[]을 반환하는 찜 목록 불러오기
   useEffect(() => {
     (async () => {
@@ -149,6 +207,46 @@ export default function FavoriteCoursesPage() {
   if (!kakaoKey) console.error("NEXT_PUBLIC_KAKAO_MAP_API_KEY undefined");
   const sdkUrl = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${kakaoKey}&libraries=services&autoload=false`;
 
+  const handleKakaoShare = () => {
+    try {
+      const kakao: any = (window as any).Kakao;
+      const pageUrl = window.location.href;
+      const titles = likedCourses.slice(0, 3).map((c) => c.title).join(', ');
+      const imageUrl = destinations[0]?.destinationThumbnailImageUrl || `${window.location.origin}/images/popular/map_pin.png`;
+
+      if (kakao && kakao.isInitialized && kakao.isInitialized()) {
+        kakao.Share.sendDefault({
+          objectType: 'feed',
+          content: {
+            title: '나의 찜한 코스',
+            description: titles
+              ? `${titles}${likedCourses.length > 3 ? ` 외 ${likedCourses.length - 3}개` : ''}`
+              : '찜한 코스를 공유합니다',
+            imageUrl,
+            link: {
+              mobileWebUrl: pageUrl,
+              webUrl: pageUrl,
+            },
+          },
+          buttons: [
+            {
+              title: '목록 보러가기',
+              link: { mobileWebUrl: pageUrl, webUrl: pageUrl },
+            },
+          ],
+        });
+      } else if (navigator.share) {
+        navigator.share({ title: '나의 찜한 코스', text: '내가 찜한 여행 코스', url: pageUrl }).catch(() => {});
+      } else {
+        navigator.clipboard.writeText(pageUrl).then(() => {
+          toast({ title: '링크가 복사되었습니다', status: 'success', duration: 1500, isClosable: true });
+        });
+      }
+    } catch (e) {
+      toast({ title: '공유 중 오류가 발생했습니다', status: 'error', duration: 1500, isClosable: true });
+    }
+  };
+
   return (
     <Layout>
       <Script
@@ -160,7 +258,7 @@ export default function FavoriteCoursesPage() {
       <div className="mt-[90px]">
         <BannerSlider />
       </div>
-      <div className="max-w-5xl mx-auto p-6 pt-[80px]">
+      <div className="max-w-7xl mx-auto px-4 md:px-8 pt-[80px]">
         <Flex
           justify="flex-end"
           align="center"
@@ -172,23 +270,41 @@ export default function FavoriteCoursesPage() {
           py={4}
           px={2}
         >
-          <Flex gap={2}>
-            <button className="px-4 py-2 rounded-full border  bg-pink-100 text-base text-pink-600 hover:bg-pink-200 font-bold">
-              공유하기 <span className="ml-1">🔗</span>
+          <Flex gap={8}>
+            <button
+              className="px-4 py-2 rounded-full border bg-yellow-100 text-base text-yellow-700 hover:bg-yellow-200 font-bold"
+              onClick={handleKakaoShare}
+            >
+              카카오톡으로 공유
             </button>
           </Flex>
         </Flex>
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold mb-4">나의 찜한 코스</h2>
-          <LikedCoursesList
-            courses={likedCourses}
-            destinations={destinations}
-          />
+        <section className="mb-10">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-2xl font-bold">나의 찜한 코스</h2>
+            <div className="hidden md:flex gap-2 text-sm text-gray-500">
+              <span className="px-3 py-1 rounded-full bg-gray-100">총 {likedCourses.length}개</span>
+            </div>
+          </div>
+          <div className="relative">
+            <div className="absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-white to-transparent pointer-events-none" />
+            <div className="absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none" />
+            <LikedCoursesList
+              courses={likedCourses}
+              destinations={destinations}
+            />
+          </div>
         </section>
         <Flex my={12} borderBottom="1px solid #eee" />
         <section style={{ position: "relative" }}>
-          <h2 className="text-2xl font-bold mb-4">찜한 코스 위치</h2>
-          {/* 지도 표시 */}
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-2xl font-bold">찜한 코스 위치</h2>
+            <div className="text-sm text-gray-500">마커를 클릭하면 해당 여행 정보로 이동합니다</div>
+          </div>
+          <div
+            id="liked-courses-map"
+            style={{ width: '100%', height: '460px', borderRadius: 16, overflow: 'hidden', boxShadow: '0 10px 30px rgba(0,0,0,0.08)' }}
+          />
         </section>
       </div>
     </Layout>

--- a/src/app/travel/popular/[id]/page.tsx
+++ b/src/app/travel/popular/[id]/page.tsx
@@ -58,6 +58,7 @@ import Footer from "@/components/common/Footer";
 import Link from "next/link";
 import NextImage from "next/image";
 import { getBestTravelSeason, getShortTermForecast, SeasonalInfo, WeatherData } from '@/services/weatherService';
+import { courseApi } from '@/services/courseService';
 
 // API 응답 타입 정의
 interface CourseDetail {
@@ -130,10 +131,11 @@ export default function TravelCourseDetail() {
         setIsLoading(true);
         
         // API 호출 상태 확인을 위한 로깅 추가
-        console.log(`코스 데이터 요청 시작: http://localhost:8080/api/course/${courseId}`);
+        const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://3.34.52.239:8080';
+        console.log(`코스 데이터 요청 시작: ${baseUrl}/api/course/${courseId}`);
         
         // 백엔드 서버로 직접 API 호출
-        const response = await fetch(`http://localhost:8080/api/course/${courseId}`, {
+        const response = await fetch(`${baseUrl}/api/course/${courseId}`, {
           mode: "cors",
           headers: {
             'Accept': 'application/json'
@@ -196,6 +198,22 @@ export default function TravelCourseDetail() {
     if (courseId) {
       fetchCourseDetail();
     }
+  }, [courseId]);
+
+  // 초기 찜 상태 조회
+  useEffect(() => {
+    const init = async () => {
+      try {
+        if (!courseId) return;
+        const token = typeof window !== 'undefined' ? sessionStorage.getItem('accessToken') : null;
+        if (!token) return;
+        const liked = await courseApi.isLiked(courseId);
+        setIsLiked(liked);
+      } catch (e) {
+        // 무시 (비로그인/네트워크 등)
+      }
+    };
+    init();
   }, [courseId]);
 
   // 날씨 데이터 및 추천 시기 로드
@@ -380,8 +398,22 @@ export default function TravelCourseDetail() {
     setHoverStyles("");
   };
 
-  const handleLikeToggle = () => {
-    setIsLiked(!isLiked);
+  const handleLikeToggle = async () => {
+    if (typeof window !== 'undefined' && !sessionStorage.getItem('accessToken')) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
+    try {
+      if (isLiked) {
+        await courseApi.unlikeCourse(courseId);
+        setIsLiked(false);
+      } else {
+        await courseApi.courseLike(String(courseId));
+        setIsLiked(true);
+      }
+    } catch (e) {
+      alert('찜하기 처리 중 오류가 발생했습니다.');
+    }
   };
 
   const handleShareClick = () => {
@@ -858,6 +890,17 @@ export default function TravelCourseDetail() {
             >
               {courseDetail.title}
             </Heading>
+
+            {/* 찜하기 버튼 */}
+            <Flex justify="center" align="center" mt={2}>
+              <IconButton
+                aria-label={isLiked ? '찜 해제' : '찜하기'}
+                icon={<Icon as={isLiked ? FaHeart : FaRegHeart} color={isLiked ? 'pink.500' : 'gray.500'} />}
+                onClick={handleLikeToggle}
+                variant="ghost"
+                size="lg"
+              />
+            </Flex>
 
             <Flex justify="center" align="center" mb={4} wrap="wrap" gap={6}>
               <Flex align="center" bg="pink.50" px={4} py={2} borderRadius="full" boxShadow="sm">

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -14,12 +14,26 @@ export const courseApi = {
     return res.data as { liked: boolean };
   },
 
+  /** 1-1) 단일 찜하기 해제 */
+  unlikeCourse: async (courseId: string | number) => {
+    const res = await api.delete(`/api/courseLike/${courseId}`, { withCredentials: true });
+    return res.data;
+  },
+
+  /** 1-2) 코스가 찜됐는지 여부 */
+  isLiked: async (courseId: string | number): Promise<boolean> => {
+    const res = await api.get(`/api/courseLike/${courseId}/liked`, { withCredentials: true });
+    return res.data as boolean;
+  },
+
   /** 2) 내 찜한 코스 전체 조회 */
   getLikedCourses: async (): Promise<Course[]> => {
     const res = await api.get(`/api/courseLike/liked`, { withCredentials: true });
-    return (res.data.data as any[]).map(course => ({
+    return (res.data.data as any[]).map((course) => ({
       ...course,
-      area: course.areaname,
+      // 서버 응답 필드명(areaName)을 클라이언트 타입(area)로 정규화
+      area: course.areaName,
+      thumbnailUrl: course.thumbnailUrl || '',
     }));
   },
 }

--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -69,23 +69,10 @@ export async function getReviews({
     const url = `${baseUrl}/api/reviews?page=${page}&size=${size}`;
     console.log(`API 호출 URL: ${url}`);
 
-    // 토큰이 있으면 헤더에 추가 (브라우저에서만)
+    // 공개 엔드포인트: Authorization 헤더 없이 요청
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
     };
-    
-    // 서버 사이드에서는 sessionStorage 접근 불가하므로 체크
-    if (typeof window !== 'undefined') {
-      const token = sessionStorage.getItem('accessToken');
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-        console.log('리뷰 목록 요청 - 토큰 포함:', token.substring(0, 20) + '...');
-      } else {
-        console.log('리뷰 목록 요청 - 토큰 없음');
-      }
-    } else {
-      console.log('서버 사이드 렌더링 - 토큰 없이 요청');
-    }
 
     const response = await fetch(url, {
       signal: controller.signal,
@@ -122,23 +109,10 @@ export async function getReviewById(id: number): Promise<Review | null> {
     const url = `${baseUrl}/api/reviews/${id}`;
     console.log(`API 호출 URL: ${url}`);
 
-    // 토큰이 있으면 헤더에 추가 (브라우저에서만)
+    // 공개 엔드포인트: Authorization 헤더 없이 요청
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
     };
-    
-    // 서버 사이드에서는 sessionStorage 접근 불가하므로 체크
-    if (typeof window !== 'undefined') {
-      const token = sessionStorage.getItem('accessToken');
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-        console.log('리뷰 상세 요청 - 토큰 포함:', token.substring(0, 20) + '...');
-      } else {
-        console.log('리뷰 상세 요청 - 토큰 없음');
-      }
-    } else {
-      console.log('서버 사이드 렌더링 - 토큰 없이 요청');
-    }
 
     const response = await fetch(url, {
       signal: controller.signal,


### PR DESCRIPTION
✨ Feat: 코스 화면 기능 개선 및 성능 최적화

TL;DR
찜하기 서버 연동(POST/DELETE/GET) 전면 적용
인기 코스 목록 로딩 최적화(단일 페치 + 이미지 fallback)
즐겨찾기 지도 마커/카카오톡 공유/상세 이동 UX 개선
카드 UI 라운드/그림자/간격/타이포 정리

주요 변경
찜하기(Like) 통합
POST/DELETE /api/courseLike/{courseId}: 찜 토글
GET /api/courseLike/{courseId}/liked: 상세 초기 상태
GET /api/courseLike/liked: 내 찜 목록


인기 코스 목록: 다중 이미지 선검증 제거 → 단일 요청 상위 N개 사용
이미지 실패 시 fallback 적용
API Base URL을 NEXT_PUBLIC_API_URL 기반으로 통일(미설정 시 http://3.34.52.239:8080 폴백)

UX 강화
즐겨찾기 페이지: 찜한 코스 위치를 카카오 지도 마커로 표시, 마커 클릭 시 상세 이동
카드(목록/즐겨찾기)·상세에 카카오톡 공유 버튼(로고) 추가
“클릭 시 상세보기” 문구 제거, 카드 전체 클릭 → 상세 이동

UI/디자인
카드 라운드(rounded), 그림자, 간격(그리드 spacingX/Y) 정리
텍스트 영역 간결화(제목 2줄, 주소 1줄 말줄임), 반응형 여백 최적화

영향 범위
client/src/services/courseService.ts
courseLike, unlikeCourse, isLiked, getLikedCourses 

추가/정리
응답 매핑 정합성(예: areaName→area, thumbnailUrl 기본값)
client/src/app/popular-courses/page.tsx

단일 페치 + fallbackSrc, 찜 토글 서버 연동
client/src/app/travel/popular/[id]/page.tsx
상세 초기 찜 상태 조회 + 토글 로직
client/src/app/travel/favorite-courses/page.tsx
지도 마커/Bounds, 마커 클릭 → 상세 이동, 카드 간격 확장, 상단 공유
client/src/app/travel/favorite-courses/_components/CourseCard.tsx
둥근 카드/섀도/텍스트 정리, 상단 우측 카카오톡 로고 공유

테스트
목록/상세 하트 토글 → 서버 반영 확인
즐겨찾기 페이지 목록과 지도 마커 동기화
카드/상세의 카카오톡 공유 동작

