### PR TITLE
fix: 리뷰 이미지 URL 처리 개선 및 서버 URL 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,8 +13,20 @@ const nextConfig = {
       { protocol: "https", hostname: "www.visitkorea.or.kr" },
       { protocol: "https", hostname: "cdn.pixabay.com" },
       { protocol: "https", hostname: "images.unsplash.com" },
+      { protocol: "http", hostname: "3.34.52.239", port: "8080" },
+      { protocol: "http", hostname: "localhost", port: "8080" },
+      { protocol: "http", hostname: "127.0.0.1", port: "8080" },
     ],
-    domains: ["cdn.pixabay.com", "apis.data.go.kr", "tong.visitkorea.or.kr", "43.200.177.95", "images.unsplash.com"],
+    domains: [
+      "cdn.pixabay.com",
+      "apis.data.go.kr",
+      "tong.visitkorea.or.kr",
+      "43.200.177.95",
+      "images.unsplash.com",
+      "3.34.52.239",
+      "localhost",
+      "127.0.0.1"
+    ],
     unoptimized: true,
   },
   webpack: (config) => {

--- a/src/app/reviews/[id]/page.tsx
+++ b/src/app/reviews/[id]/page.tsx
@@ -124,7 +124,7 @@ export default function ReviewPage() {
                       {otherReview.images && otherReview.images.length > 0 ? (
                         <div className="relative aspect-[4/3] overflow-hidden">
                           <img
-                            src={`${process.env.NEXT_PUBLIC_API_URL || ''}${otherReview.images[0].imageUrl}`}
+                            src={`${(process.env.NEXT_PUBLIC_API_URL || 'http://3.34.52.239:8080').replace(/\/$/, '')}${otherReview.images[0].imageUrl.startsWith('http') ? '' : (otherReview.images[0].imageUrl.startsWith('/') ? '' : '/image/')}${otherReview.images[0].imageUrl}`}
                             alt={otherReview.title}
                             className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
                           />

--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -23,13 +23,20 @@ export default function ReviewCard({ review }: ReviewCardProps) {
     if (imageUrl.startsWith('http')) {
       return imageUrl; // 이미 절대 URL인 경우
     }
-    // 환경변수가 없으면 빈 문자열 반환 (개발 환경에서 경고)
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'http://3.34.52.239:8080').replace(/\/$/, '');
     if (!apiUrl) {
       console.warn('NEXT_PUBLIC_API_URL이 설정되지 않았습니다.');
       return imageUrl;
     }
-    return `${apiUrl}${imageUrl}`;
+    // 서버는 파일명만 반환하므로 /image/{파일명}으로 보정
+    if (imageUrl.startsWith('/')) {
+      const finalUrl = `${apiUrl}${imageUrl}`;
+      if (process.env.NODE_ENV !== 'production') console.log('[ReviewCard] imageUrl(mapped):', finalUrl);
+      return finalUrl;
+    }
+    const finalUrl = `${apiUrl}/image/${imageUrl}`;
+    if (process.env.NODE_ENV !== 'production') console.log('[ReviewCard] imageUrl(mapped):', finalUrl);
+    return finalUrl;
   };
 
   const renderStarRating = (rating: number) => {
@@ -75,10 +82,13 @@ export default function ReviewCard({ review }: ReviewCardProps) {
                     className={`object-cover transition-all duration-700 group-hover:scale-110 ${
                       imageLoading ? 'opacity-0' : 'opacity-100'
                     }`}
-                    onError={() => setImgError(true)}
+                    onError={(e) => {
+                      setImgError(true);
+                      if (process.env.NODE_ENV !== 'production') console.error('[ReviewCard] image onError:', (e as any)?.currentTarget?.src);
+                    }}
                     onLoad={() => setImageLoading(false)}
                     priority
-                    unoptimized={true}
+                    unoptimized
                   />
                 ) : (
                   <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-pink-50 to-rose-100">

--- a/src/components/reviews/ReviewDetail.tsx
+++ b/src/components/reviews/ReviewDetail.tsx
@@ -48,11 +48,20 @@ export default function ReviewDetail({ review }: ReviewDetailProps) {
   const isOwner = currentUser === review.nickname;
 
   // 이미지 URL 처리
+  // 업로드 경로 폴백 제거: 서버는 파일명만 반환하며 정적 경로는 /image/{filename}로 통일
+
   const getImageUrl = (imageUrl: string) => {
     if (!imageUrl) return '';
     if (imageUrl.startsWith('http')) return imageUrl;
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-    return `${apiUrl}${imageUrl}`;
+    const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'http://3.34.52.239:8080').replace(/\/$/, '');
+    if (imageUrl.startsWith('/')) {
+      const finalUrl = `${apiUrl}${imageUrl}`;
+      if (process.env.NODE_ENV !== 'production') console.log('[ReviewDetail] imageUrl(mapped):', finalUrl);
+      return finalUrl;
+    }
+    const finalUrl = `${apiUrl}/image/${imageUrl}`;
+    if (process.env.NODE_ENV !== 'production') console.log('[ReviewDetail] imageUrl(mapped):', finalUrl);
+    return finalUrl;
   };
 
   // 유효한 이미지 필터링
@@ -223,7 +232,7 @@ export default function ReviewDetail({ review }: ReviewDetailProps) {
                   alt={review.title}
                   fill
                   className="object-cover hover:brightness-95 transition-all"
-                  onError={() => handleImageError(getImageUrl(validImages[selectedImageIndex].imageUrl))}
+                  onError={() => { const key = validImages[selectedImageIndex].imageUrl; const u = getImageUrl(key); handleImageError(u); if (process.env.NODE_ENV !== 'production') console.error('[ReviewDetail] image onError:', u); }}
                   priority
                   unoptimized
                 />
@@ -253,7 +262,7 @@ export default function ReviewDetail({ review }: ReviewDetailProps) {
                         alt={`${review.title} ${index + 2}`}
                         fill
                         className="object-cover hover:brightness-95 transition-all"
-                        onError={() => handleImageError(getImageUrl(image.imageUrl))}
+                        onError={() => { const key = image.imageUrl; const u = getImageUrl(key); handleImageError(u); if (process.env.NODE_ENV !== 'production') console.error('[ReviewDetail] thumb onError:', u); }}
                         unoptimized
                       />
                       {index === 3 && validImages.length > 5 && (

--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -192,8 +192,9 @@ export async function createReview(
 
     const formData = new FormData();
     
-    // 리뷰 데이터를 JSON으로 추가
-    formData.append('review', JSON.stringify(reviewData));
+    // 리뷰 데이터를 JSON으로 추가 (Blob으로 감싸 Content-Type 지정)
+    const reviewBlob = new Blob([JSON.stringify(reviewData)], { type: 'application/json' });
+    formData.append('review', reviewBlob);
     console.log('리뷰 데이터:', reviewData);
     
     // 이미지 파일들 추가
@@ -256,8 +257,9 @@ export async function updateReview(
 
     const formData = new FormData();
     
-    // 리뷰 데이터를 JSON으로 추가
-    formData.append('review', JSON.stringify(reviewData));
+    // 리뷰 데이터를 JSON으로 추가 (Blob으로 감싸 Content-Type 지정)
+    const reviewBlob = new Blob([JSON.stringify(reviewData)], { type: 'application/json' });
+    formData.append('review', reviewBlob);
     
     // 이미지 파일들 추가
     if (images && images.length > 0) {


### PR DESCRIPTION
변경 사항 요약
리뷰 이미지 URL 처리를 단일 규칙으로 통일: 서버가 파일명만 주면 클라이언트는 항상 API_URL/image/{파일명}으로 접근.
/uploads/review-images 폴백 및 관련 상태/로직 제거.
원격 이미지 로딩 안정화를 위해 next/image 설정 보완 및 unoptimized 사용.


관련 이슈
Closes #114 

변경 파일
client/src/components/reviews/ReviewCard.tsx
getImageUrl: 항상 ${apiUrl}/image/{filename} 반환.
uploadsFallback 상태 및 /uploads/review-images 폴백 로직 제거.
onError에서 폴백 전환 제거, 에러 표시만 수행.
client/src/components/reviews/ReviewDetail.tsx
getImageUrl: 항상 ${apiUrl}/image/{filename} 반환.
uploadsFallback 상태 및 썸네일/라이트박스 onError 폴백 제거.
유효 이미지 필터링 로직은 유지, 반응형 레이아웃 영향 없음.
client/next.config.js (이 PR 범위에 포함되는 경우)
images.remotePatterns/domains에 http://3.34.52.239:8080, http://localhost:8080, http://127.0.0.1:8080 추가.
images.unoptimized: true 설정으로 개발 환경 프록시 400 이슈 회피.
client/src/services/reviewService.ts (이 PR 범위에 포함되는 경우)
FormData에 review JSON을 Blob으로 첨부해 서버 Multipart 파싱 안정화.
클라이언트 폴백 로직을 제거해 단순화 및 유지보수성 향상.
Next.js 이미지 최적화 프록시 이슈(400) 회피로 개발/운영 환경 모두에서 안정적 로딩.

테스트 방법

환경 변수
.env.local: NEXT_PUBLIC_API_URL=http://localhost:8080 (운영: http://3.34.52.239:8080)

수동 테스트
npm run dev 후 리뷰 리스트/상세 접속.
네트워크 탭에서 이미지 요청이 모두 GET {API_URL}/image/{파일명} 인지 확인.
200 응답이며 콘솔에 [ReviewCard] image onError/[ReviewDetail] image onError가 더 이상 /uploads/...로 찍히지 않는지 확인.
다양한 화면폭(모바일/태블릿/데스크탑)에서 이미지가 반응형으로 정상 표시되는지 확인.
추가 확인
next.config.js에 원격 호스트가 반영되어 빌드 경고/에러가 없는지 확인.

체크리스트
[ ] 코드 리뷰 완료
[ ] 모든 테스트 통과
[ ] 문서 및 주석 업데이트 완료 (해당 시)